### PR TITLE
Adding keepOpen capability to the Endpoint Circuit Breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Camel Route Policy
+# Camel Route Policy: Endpoint Circuit Breaker
 
-Initial code as proof concept for creating a Camel Circuit Breaker that would stop reading from an endpoint if an error threshold was met. 
+Initial code as proof concept for creating a Circuit Breaker EIP implementation that would stop reading from an endpoint on a Camel Route if an error threshold was met. 
 
-This was made available in Camel 2.19
+The initial capability was made available in Camel 2.19
+- see [CAMEL-10718](https://issues.apache.org/jira/browse/CAMEL-10718)
 
-More can be found [here](https://theagilejedi.wordpress.com/2017/05/11/yet-another-camel-circuit-breaker/)
+The `keepOpen` capability is pending
+- see [CAMEL-12125](https://issues.apache.org/jira/browse/CAMEL-12125)
+
+More details on how it works can be found [here](https://theagilejedi.wordpress.com/2017/05/11/yet-another-camel-circuit-breaker/)

--- a/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyKeepOpenOnInitTest.java
+++ b/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyKeepOpenOnInitTest.java
@@ -1,0 +1,92 @@
+package codesmell.camel.routepolicy;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class ThrottlingExceptionRoutePolicyKeepOpenOnInitTest extends CamelTestSupport {
+
+    private String url = "seda:foo?concurrentConsumers=20";
+    private MockEndpoint result;
+    private int size = 5;
+
+    private ThrottlingExceptionRoutePolicy policy;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+        context.getShutdownStrategy().setTimeout(1);
+    }
+
+    @Test
+    public void testThrottlingRoutePolicyStartWithAlwaysOpenOn() throws Exception {
+        result.expectedMessageCount(0);
+
+        for (int i = 0; i < size; i++) {
+            template.sendBody(url, "Message " + i);
+            Thread.sleep(3);
+        }
+
+        // gives time for policy half open check to run every second
+        // and should not close b/c keepOpen is true
+        Thread.sleep(2000);
+
+        // gives time for policy half open check to run every second
+        // but it should never close b/c keepOpen is true
+        assertMockEndpointsSatisfied(1000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testThrottlingRoutePolicyStartWithAlwaysOpenOnThenClose() throws Exception {
+//        result.expectedMessageCount(size);
+
+        for (int i = 0; i < size; i++) {
+            template.sendBody(url, "Message " + i);
+            Thread.sleep(3);
+        }
+
+        // gives time for policy half open check to run every second
+        // and should not close b/c keepOpen is true
+        Thread.sleep(2000);
+
+        result.expectedMessageCount(0);
+        assertMockEndpointsSatisfied(2000, TimeUnit.MILLISECONDS);
+
+        // set keepOpen to false
+        // now half open check will succeed
+        policy.setKeepOpen(false);
+
+        // gives time for policy half open check to run every second
+        // and should close and get all the messages
+        result.expectedMessageCount(5);
+        assertMockEndpointsSatisfied(2000, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 1000;
+                boolean keepOpen = true;
+                policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null, keepOpen);
+
+                from(url)
+                    .routePolicy(policy)
+                    .log("${body}")
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+
+}

--- a/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyKeepOpenOnInitTest.java
+++ b/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyKeepOpenOnInitTest.java
@@ -45,7 +45,6 @@ public class ThrottlingExceptionRoutePolicyKeepOpenOnInitTest extends CamelTestS
 
     @Test
     public void testThrottlingRoutePolicyStartWithAlwaysOpenOnThenClose() throws Exception {
-//        result.expectedMessageCount(size);
 
         for (int i = 0; i < size; i++) {
             template.sendBody(url, "Message " + i);

--- a/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
+++ b/src/test/java/codesmell/camel/routepolicy/ThrottlingExceptionRoutePolicyOpenViaConfigTest.java
@@ -1,0 +1,91 @@
+package codesmell.camel.routepolicy;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class ThrottlingExceptionRoutePolicyOpenViaConfigTest extends CamelTestSupport {
+    private static Logger log = LoggerFactory.getLogger(ThrottlingExceptionRoutePolicyOpenViaConfigTest.class);
+
+    private String url = "seda:foo?concurrentConsumers=20";
+    private MockEndpoint result;
+    private int size = 5;
+
+    private ThrottlingExceptionRoutePolicy policy;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.setUseRouteBuilder(true);
+        result = getMockEndpoint("mock:result");
+
+        context.getShutdownStrategy().setTimeout(1);
+
+        // start off policy w/ open circuit
+        policy.setKeepOpen(false);
+    }
+
+
+    @Test
+    public void testThrottlingRoutePolicyAlwaysOpen() throws Exception {
+        result.expectedMinimumMessageCount(0);
+
+        for (int i = 0; i < size; i++) {
+            template.sendBody(url, "Message " + i);
+            Thread.sleep(3);
+        }
+
+        // gives time for policy half open check to run every second
+        // but it should never close b/c keepOpen is true
+        assertMockEndpointsSatisfied(5000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testThrottlingRoutePolicyAlwaysOpenClosed() throws Exception {
+        result.expectedMinimumMessageCount(size);
+
+        for (int i = 0; i < size; i++) {
+            template.sendBody(url, "Message " + i);
+            Thread.sleep(3);
+        }
+
+        // gives time for policy half open check to run every second
+        // and should not close b/c keepOpen is true
+        Thread.sleep(3000);
+
+        // set keepOpen to false
+        // now half open check will succeed
+        policy.setKeepOpen(false);
+
+        // gives time for policy half open check to run every second
+        // and should close and get all the messages
+        assertMockEndpointsSatisfied(2000, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                int threshold = 2;
+                long failureWindow = 30;
+                long halfOpenAfter = 1000;
+                policy = new ThrottlingExceptionRoutePolicy(threshold, failureWindow, halfOpenAfter, null);
+
+                from(url)
+                    .routePolicy(policy)
+                    .log("${body}")
+                    .to("log:foo?groupSize=10")
+                    .to("mock:result");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
adding the ability to force circuit breaker into the open state so that it suspends consuming even if there are no exceptions. This functions similar to the Netflix Hystrix `forceOpen` option.

https://github.com/Netflix/Hystrix/wiki/Configuration#circuitBreaker.forceOpen  
https://issues.apache.org/jira/browse/CAMEL-12125